### PR TITLE
Publish containers to docker.io

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,21 +21,20 @@ jobs:
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v4
       - uses: docker/metadata-action@v5
         id: meta
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: uatuko/ruek
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
       - name: Build and publish
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: Containerfile
@@ -44,9 +43,3 @@ jobs:
             linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-      - uses: actions/delete-package-versions@v5
-        with:
-          package-name: ruek
-          package-type: container
-          min-versions-to-keep: 2
-          delete-only-untagged-versions: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,17 +17,23 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v4
       - uses: docker/metadata-action@v5
         id: meta
         with:
-          images: uatuko/ruek
+          images: |
+            ${{ github.repository }}
+            ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
@@ -36,6 +42,7 @@ jobs:
       - name: Build and publish
         uses: docker/build-push-action@v6
         with:
+          annotations: ${{ steps.meta.outputs.annotations }}
           context: .
           file: Containerfile
           platforms: |
@@ -43,3 +50,9 @@ jobs:
             linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+      - uses: actions/delete-package-versions@v5
+        with:
+          package-name: ruek
+          package-type: container
+          min-versions-to-keep: 2
+          delete-only-untagged-versions: true

--- a/bin/march.sh
+++ b/bin/march.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+
+: ${ruek_march=unknown}
+
+if [ -z ${TARGETARCH} ]; then
+	TARGETARCH=$(uname -m)
+fi
+
+case ${TARGETARCH} in
+	amd64 | x86_64)
+		ruek_march=x86_64
+		;;
+	aarch64 | arm64)
+		ruek_march=aarch64
+		;;
+esac
+
+echo ${ruek_march}

--- a/src/svc/authz.h
+++ b/src/svc/authz.h
@@ -17,16 +17,6 @@ public:
 		return {grpcxx::status::code_t::unimplemented, std::nullopt};
 	}
 
-	template <>
-	rpcCheck::result_type call<rpcCheck>(grpcxx::context &ctx, const rpcCheck::request_type &req);
-
-	template <>
-	rpcGrant::result_type call<rpcGrant>(grpcxx::context &ctx, const rpcGrant::request_type &req);
-
-	template <>
-	rpcRevoke::result_type call<rpcRevoke>(
-		grpcxx::context &ctx, const rpcRevoke::request_type &req);
-
 	google::rpc::Status exception() noexcept;
 
 private:
@@ -35,5 +25,15 @@ private:
 	db::Tuple map(const grpcxx::context &ctx, const rpcGrant::request_type &from) const noexcept;
 	rpcGrant::response_type map(const db::Tuple &from) const noexcept;
 };
+
+template <>
+rpcCheck::result_type Impl::call<rpcCheck>(grpcxx::context &ctx, const rpcCheck::request_type &req);
+
+template <>
+rpcGrant::result_type Impl::call<rpcGrant>(grpcxx::context &ctx, const rpcGrant::request_type &req);
+
+template <>
+rpcRevoke::result_type Impl::call<rpcRevoke>(
+	grpcxx::context &ctx, const rpcRevoke::request_type &req);
 } // namespace authz
 } // namespace svc

--- a/src/svc/entities.h
+++ b/src/svc/entities.h
@@ -18,23 +18,23 @@ public:
 		return {grpcxx::status::code_t::unimplemented, std::nullopt};
 	}
 
-	template <>
-	rpcList::result_type call<rpcList>(grpcxx::context &ctx, const rpcList::request_type &req);
-
-	template <>
-	rpcListPrincipals::result_type call<rpcListPrincipals>(
-		grpcxx::context &ctx, const rpcListPrincipals::request_type &req);
-
 	google::rpc::Status exception() noexcept;
 
 private:
 	template <typename T, typename F> T map(const F &) const noexcept;
-
-	template <> rpcList::response_type           map(const db::Tuples &from) const noexcept;
-	template <> rpcListPrincipals::response_type map(const db::Tuples &from) const noexcept;
-
-	template <> ruek::api::v1::EntitiesEntity    map(const db::Tuple &from) const noexcept;
-	template <> ruek::api::v1::EntitiesPrincipal map(const db::Tuple &from) const noexcept;
 };
+
+template <>
+rpcList::result_type Impl::call<rpcList>(grpcxx::context &ctx, const rpcList::request_type &req);
+
+template <>
+rpcListPrincipals::result_type Impl::call<rpcListPrincipals>(
+	grpcxx::context &ctx, const rpcListPrincipals::request_type &req);
+
+template <> rpcList::response_type           Impl::map(const db::Tuples &from) const noexcept;
+template <> rpcListPrincipals::response_type Impl::map(const db::Tuples &from) const noexcept;
+
+template <> ruek::api::v1::EntitiesEntity    Impl::map(const db::Tuple &from) const noexcept;
+template <> ruek::api::v1::EntitiesPrincipal Impl::map(const db::Tuple &from) const noexcept;
 } // namespace entities
 } // namespace svc

--- a/src/svc/principals.h
+++ b/src/svc/principals.h
@@ -18,25 +18,6 @@ public:
 		return {grpcxx::status::code_t::unimplemented, std::nullopt};
 	}
 
-	template <>
-	rpcCreate::result_type call<rpcCreate>(
-		grpcxx::context &ctx, const rpcCreate::request_type &req);
-
-	template <>
-	rpcDelete::result_type call<rpcDelete>(
-		grpcxx::context &ctx, const rpcDelete::request_type &req);
-
-	template <>
-	rpcList::result_type call<rpcList>(grpcxx::context &ctx, const rpcList::request_type &req);
-
-	template <>
-	rpcRetrieve::result_type call<rpcRetrieve>(
-		grpcxx::context &ctx, const rpcRetrieve::request_type &req);
-
-	template <>
-	rpcUpdate::result_type call<rpcUpdate>(
-		grpcxx::context &ctx, const rpcUpdate::request_type &req);
-
 	google::rpc::Status exception() noexcept;
 
 private:
@@ -46,5 +27,24 @@ private:
 	rpcCreate::response_type map(const db::Principal &from) const noexcept;
 	rpcList::response_type   map(const db::Principals &from) const noexcept;
 };
+
+template <>
+rpcCreate::result_type Impl::call<rpcCreate>(
+	grpcxx::context &ctx, const rpcCreate::request_type &req);
+
+template <>
+rpcDelete::result_type Impl::call<rpcDelete>(
+	grpcxx::context &ctx, const rpcDelete::request_type &req);
+
+template <>
+rpcList::result_type Impl::call<rpcList>(grpcxx::context &ctx, const rpcList::request_type &req);
+
+template <>
+rpcRetrieve::result_type Impl::call<rpcRetrieve>(
+	grpcxx::context &ctx, const rpcRetrieve::request_type &req);
+
+template <>
+rpcUpdate::result_type Impl::call<rpcUpdate>(
+	grpcxx::context &ctx, const rpcUpdate::request_type &req);
 } // namespace principals
 } // namespace svc

--- a/src/svc/relations.h
+++ b/src/svc/relations.h
@@ -21,25 +21,6 @@ public:
 		return {grpcxx::status::code_t::unimplemented, std::nullopt};
 	}
 
-	template <>
-	rpcCheck::result_type call<rpcCheck>(grpcxx::context &ctx, const rpcCheck::request_type &req);
-
-	template <>
-	rpcCreate::result_type call<rpcCreate>(
-		grpcxx::context &ctx, const rpcCreate::request_type &req);
-
-	template <>
-	rpcDelete::result_type call<rpcDelete>(
-		grpcxx::context &ctx, const rpcDelete::request_type &req);
-
-	template <>
-	rpcListLeft::result_type call<rpcListLeft>(
-		grpcxx::context &ctx, const rpcListLeft::request_type &req);
-
-	template <>
-	rpcListRight::result_type call<rpcListRight>(
-		grpcxx::context &ctx, const rpcListRight::request_type &req);
-
 	google::rpc::Status exception() noexcept;
 
 private:
@@ -71,5 +52,24 @@ private:
 		std::string_view spaceId, db::Tuple::Entity left, std::string_view relation,
 		db::Tuple::Entity right, std::uint16_t limit) const;
 };
+
+template <>
+rpcCheck::result_type Impl::call<rpcCheck>(grpcxx::context &ctx, const rpcCheck::request_type &req);
+
+template <>
+rpcCreate::result_type Impl::call<rpcCreate>(
+	grpcxx::context &ctx, const rpcCreate::request_type &req);
+
+template <>
+rpcDelete::result_type Impl::call<rpcDelete>(
+	grpcxx::context &ctx, const rpcDelete::request_type &req);
+
+template <>
+rpcListLeft::result_type Impl::call<rpcListLeft>(
+	grpcxx::context &ctx, const rpcListLeft::request_type &req);
+
+template <>
+rpcListRight::result_type Impl::call<rpcListRight>(
+	grpcxx::context &ctx, const rpcListRight::request_type &req);
 } // namespace relations
 } // namespace svc


### PR DESCRIPTION
There seems to be an issue with `ghcr.io` where published containers can't be pulled ('manifest unknown' error), so moving to `docker.io`.

**Update:** https://github.com/docker/build-push-action/issues/820#issuecomment-1486849546 suggested the issue could be due to cross-compiling/how multi-arch images are created. After updating the builds to use g++ cross-compile (instead of using QEMU to create multi-arch containers) it seems `docker` can pull ghcr.io images now.

## Notes

### 10th November, 2024

Inspecting the builds produced by https://github.com/uatuko/ruek/actions/runs/11767516276 seems to show both ghcr.io and docker.io having the same build manifests.

<details>
<summary>ghcr.io/uatuko/ruek</summary>

```
$ docker buildx imagetools inspect ghcr.io/uatuko/ruek
Name:      ghcr.io/uatuko/ruek:latest
MediaType: application/vnd.oci.image.index.v1+json
Digest:    sha256:ef793b77c8d85473ad96fadb3309bbad2a847ef58d9c931cfaba5b2b682c5320
           
Manifests: 
  Name:        ghcr.io/uatuko/ruek:latest@sha256:c9835b44612c7004bbcd2b2e99ae5083374547aceb6c8725ce45e2979077cc6a
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    linux/amd64
               
  Name:        ghcr.io/uatuko/ruek:latest@sha256:938d19eed563953d922a5182803d41c4f948256b61987e710a10b80fffb33532
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    linux/arm64
               
  Name:        ghcr.io/uatuko/ruek:latest@sha256:68f30d71fa085f00e50515336eb7bda17d9ec06455e417c03ad24debb629a3aa
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    unknown/unknown
  Annotations: 
    vnd.docker.reference.digest: sha256:c9835b44612c7004bbcd2b2e99ae5083374547aceb6c8725ce45e2979077cc6a
    vnd.docker.reference.type:   attestation-manifest
               
  Name:        ghcr.io/uatuko/ruek:latest@sha256:50eb440b657ed3ddd06b0098ca4413441e70dc254942e0c230aaf22c110bb4fe
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    unknown/unknown
  Annotations: 
    vnd.docker.reference.digest: sha256:938d19eed563953d922a5182803d41c4f948256b61987e710a10b80fffb33532
    vnd.docker.reference.type:   attestation-manifest
```
</details>

<details>
<summary>docker.io/uatuko/ruek</summary>

```
$ docker buildx imagetools inspect uatuko/ruek
Name:      docker.io/uatuko/ruek:latest
MediaType: application/vnd.oci.image.index.v1+json
Digest:    sha256:ef793b77c8d85473ad96fadb3309bbad2a847ef58d9c931cfaba5b2b682c5320
           
Manifests: 
  Name:        docker.io/uatuko/ruek:latest@sha256:c9835b44612c7004bbcd2b2e99ae5083374547aceb6c8725ce45e2979077cc6a
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    linux/amd64
               
  Name:        docker.io/uatuko/ruek:latest@sha256:938d19eed563953d922a5182803d41c4f948256b61987e710a10b80fffb33532
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    linux/arm64
               
  Name:        docker.io/uatuko/ruek:latest@sha256:68f30d71fa085f00e50515336eb7bda17d9ec06455e417c03ad24debb629a3aa
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    unknown/unknown
  Annotations: 
    vnd.docker.reference.digest: sha256:c9835b44612c7004bbcd2b2e99ae5083374547aceb6c8725ce45e2979077cc6a
    vnd.docker.reference.type:   attestation-manifest
               
  Name:        docker.io/uatuko/ruek:latest@sha256:50eb440b657ed3ddd06b0098ca4413441e70dc254942e0c230aaf22c110bb4fe
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    unknown/unknown
  Annotations: 
    vnd.docker.reference.type:   attestation-manifest
    vnd.docker.reference.digest: sha256:938d19eed563953d922a5182803d41c4f948256b61987e710a10b80fffb33532
```
</details>


However, while docker.io images can be pulled ghcr.io images gives "manifest unknown" error. 

```
❯ podman version
Client:       Podman Engine
Version:      5.0.2
API Version:  5.0.2
Go Version:   go1.22.2
Built:        Thu Jan  1 01:00:00 1970
OS/Arch:      darwin/arm64

Server:       Podman Engine
Version:      5.0.2
API Version:  5.0.2
Go Version:   go1.21.9
Built:        Wed Apr 17 01:00:00 2024
OS/Arch:      linux/arm64
```

```
❯ podman pull ghcr.io/uatuko/ruek
Error: copying system image from manifest list: determining manifest MIME type for docker://ghcr.io/uatuko/ruek:latest: reading manifest sha256:938d19eed563953d922a5182803d41c4f948256b61987e710a10b80fffb33532 in ghcr.io/uatuko/ruek: manifest unknown
```

```
❯ podman pull docker.io/uatuko/ruek
Trying to pull docker.io/uatuko/ruek:latest...
Getting image source signatures
Copying blob sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
Copying blob sha256:83d624c4be2db5b81ae220b6b10cbc9a559d5800fd32556f4020727098f71ed0
Copying blob sha256:433e9a8d63bc93d3fa1577ea8dd83d5ae2b459fc6769dc02712b11c964bd517a
Copying blob sha256:4de672e29a23ae2e35a92b07b9bf8dec9e9f9b3a50a92f926539c6c83a19b30a
Copying config sha256:de489992aed217550d385f377fd9f66407d5d79d99d31c6723cb2ff44bf9b066
Writing manifest to image destination
de489992aed217550d385f377fd9f66407d5d79d99d31c6723cb2ff44bf9b066
```

**Update - 1:** It used to be both `podman` and `docker` gave the same "manifest unknown" result. However, after inspecting images using `docker` and pulling from docker.io first, I can now pull `ghcr.io/uatuko/ruek` image as well (could be a coincident?)

```
$ docker version
Client: Docker Engine - Community
 Version:           27.3.1
 API version:       1.47
 Go version:        go1.22.7
 Git commit:        ce12230
 Built:             Fri Sep 20 11:40:59 2024
 OS/Arch:           linux/amd64
 Context:           default

Server: Docker Engine - Community
 Engine:
  Version:          27.3.1
  API version:      1.47 (minimum version 1.24)
  Go version:       go1.22.7
  Git commit:       41ca978
  Built:            Fri Sep 20 11:40:59 2024
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.7.22
  GitCommit:        7f7fdf5fed64eb6a7caf99b3e12efcf9d60e311c
 runc:
  Version:          1.1.14
  GitCommit:        v1.1.14-0-g2c9f560
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```

```
$ docker pull ghcr.io/uatuko/ruek
Using default tag: latest
latest: Pulling from uatuko/ruek
a480a496ba95: Pull complete 
17343da46eca: Pull complete 
4de672e29a23: Pull complete 
4f4fb700ef54: Pull complete 
Digest: sha256:ef793b77c8d85473ad96fadb3309bbad2a847ef58d9c931cfaba5b2b682c5320
Status: Downloaded newer image for ghcr.io/uatuko/ruek:latest
ghcr.io/uatuko/ruek:latest
```

**Update - 2:** Well, it looks like after https://github.com/uatuko/ruek/actions/runs/11768032663 even `podman` now works. But the docker.io image was pulled before the ghcr.io image. 

```
❯ podman pull docker.io/uatuko/ruek
Trying to pull docker.io/uatuko/ruek:latest...
Getting image source signatures
Copying blob sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
Copying blob sha256:4fbb5dc64dfa7c0fffc8c2ff6b3569d2a08f5175a0f673f53fec8a34de981616
Copying blob sha256:2ce94b48a51d5ad0d5daada3ca8e061912e32c4cf8163d027b3262a74b2ee451
Copying blob sha256:83d624c4be2db5b81ae220b6b10cbc9a559d5800fd32556f4020727098f71ed0
Copying config sha256:a9179c9cc06fde60cf246638c980a0a7cb3212a75d34f9b40873cefa00de0a5e
Writing manifest to image destination
a9179c9cc06fde60cf246638c980a0a7cb3212a75d34f9b40873cefa00de0a5e
```

```
❯ podman pull ghcr.io/uatuko/ruek
Trying to pull ghcr.io/uatuko/ruek:latest...
Getting image source signatures
Copying blob sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
Copying blob sha256:83d624c4be2db5b81ae220b6b10cbc9a559d5800fd32556f4020727098f71ed0
Copying blob sha256:4fbb5dc64dfa7c0fffc8c2ff6b3569d2a08f5175a0f673f53fec8a34de981616
Copying blob sha256:2ce94b48a51d5ad0d5daada3ca8e061912e32c4cf8163d027b3262a74b2ee451
Copying config sha256:a9179c9cc06fde60cf246638c980a0a7cb3212a75d34f9b40873cefa00de0a5e
Writing manifest to image destination
a9179c9cc06fde60cf246638c980a0a7cb3212a75d34f9b40873cefa00de0a5e
```