### PR TITLE
Fix to return correct gRPC errors when creating duplicate relations

### DIFF
--- a/src/svc/relations.cpp
+++ b/src/svc/relations.cpp
@@ -340,6 +340,9 @@ google::rpc::Status Impl::exception() noexcept {
 
 	try {
 		std::rethrow_exception(std::current_exception());
+	} catch (const err::DbTupleAlreadyExists &e) {
+		status.set_code(google::rpc::ALREADY_EXISTS);
+		status.set_message(std::string(e.str()));
 	} catch (const err::DbTupleInvalidData &e) {
 		status.set_code(google::rpc::INVALID_ARGUMENT);
 		status.set_message(std::string(e.str()));

--- a/src/svc/relations_test.cpp
+++ b/src/svc/relations_test.cpp
@@ -1065,6 +1065,39 @@ TEST_F(svc_RelationsTest, Create) {
 
 		EXPECT_FALSE(result.response);
 	}
+
+	// Error: duplicate relation
+	{
+		db::Tuple tuple({
+			.lEntityId   = "left",
+			.lEntityType = "svc_RelationsTest.Create-duplicate",
+			.relation    = "relation",
+			.rEntityId   = "right",
+			.rEntityType = "svc_RelationsTest.Create-duplicate",
+		});
+		ASSERT_NO_THROW(tuple.store());
+
+		rpcCreate::request_type request;
+
+		auto *left = request.mutable_left_entity();
+		left->set_id(tuple.lEntityId());
+		left->set_type(tuple.lEntityType());
+
+		request.set_relation(tuple.relation());
+
+		auto *right = request.mutable_right_entity();
+		right->set_id(tuple.rEntityId());
+		right->set_type(tuple.rEntityType());
+
+		rpcCreate::result_type result;
+		EXPECT_NO_THROW(result = svc.call<rpcCreate>(ctx, request));
+
+		EXPECT_EQ(grpcxx::status::code_t::already_exists, result.status.code());
+		EXPECT_EQ(
+			"CAYSJVtydWVrOjEuNC40LjQwOV0gVHVwbGUgYWxyZWFkeSBleGlzdHM=", result.status.details());
+
+		EXPECT_FALSE(result.response);
+	}
 }
 
 TEST_F(svc_RelationsTest, Delete) {


### PR DESCRIPTION
Return `ALREADY_EXISTS` gRPC status when creating duplicate relations.