### PR TITLE
Fix publish workflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.27)
 project(ruek VERSION 0.3.1 LANGUAGES CXX)
 
 cmake_policy(SET CMP0135 NEW)

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM debian:12-slim AS builder
+FROM --platform=$BUILDPLATFORM ubuntu:24.04 AS builder
 
 ARG TARGETARCH
 
@@ -28,7 +28,7 @@ RUN ruek_march=$(./source/bin/march.sh) \
 RUN cmake --build build/ --config Release
 
 
-FROM debian:12-slim
+FROM debian:ubuntu:24.04
 
 RUN apt-get update \
 	&& \


### PR DESCRIPTION
Use `ubuntu:24.04` for container builds since gRPCxx v0.6.1 require cmake 3.27 (which isn't available in current stable `debian:12-slim`).