### PR TITLE
Tidy-up db schema

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -41,7 +41,7 @@ create table if not exists tuples (
 	-- Self references for computed tuples
 	--
 	_rid_l  text,
-	_rid_r  text, 
+	_rid_r  text,
 
 	constraint "tuples.pkey" primary key (_id),
 	constraint "tuples.unique" unique (

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -30,11 +30,6 @@ create table if not exists tuples (
 
 	attrs  jsonb,
 
-	-- Duplicate columns for foreign key constraints if either left/right entity refer to a principal
-	--
-	l_principal_id  text,
-	r_principal_id  text,
-
 	_id   text    not null,
 	_rev  integer not null,
 
@@ -62,14 +57,6 @@ create table if not exists tuples (
 
 	constraint "tuples.fkey-_rid_r" foreign key (_rid_r)
 		references tuples(_id)
-		on delete cascade,
-
-	constraint "tuples.fkey-space_id+l_principal_id" foreign key (space_id, l_principal_id)
-		references principals(space_id, id)
-		on delete cascade,
-
-	constraint "tuples.fkey-space_id+r_principal_id" foreign key (space_id, r_principal_id)
-		references principals(space_id, id)
 		on delete cascade,
 
 	constraint "tuples.check-l_entity_id" check (l_entity_id <> ''),

--- a/docs/api/v1/principals.md
+++ b/docs/api/v1/principals.md
@@ -175,14 +175,17 @@ rpc Update(PrincipalsUpdateRequest) returns (Principal);
 
 ### PrincipalsDeleteRequest
 
-| Field   | Type      | Description |
-| ------- | --------- | ----------- |
-| id      | `string`  | |
+| Field      | Type                | Description |
+| ---------- | ------------------- | ----------- |
+| id         | `string`            | |
+| cost_limit | (optional) `uint32` | A value between `1` and `65535` to limit the delete cost (default `1000`). |
 
 ### PrincipalsDeleteResponse
 
-| Field   | Type                | Description |
-| ------- | ------------------- | ----------- |
+| Field            | Type       | Description |
+| ---------------- | -----------| ----------- |
+| cost             | `int32`    | Delete cost. A negative cost indicates the delete cost exceeded the limit and the delete action was aborted. |
+| failed_tuple_ids | `[]string` | List of relation tuple ids that were referencing the deleted principal but failed to delete. The caller _must_ delete these tuples to ensure data consistency. |
 
 ### PrincipalsListRequest
 

--- a/docs/api/v1/relations.md
+++ b/docs/api/v1/relations.md
@@ -16,12 +16,15 @@ service Relations {}
 - [(rpc) Delete (`ruek.api.v1.Relations.Delete`)](#rpc-delete-ruekapiv1relationsdelete)
   - [Request message](#request-message-2)
   - [Response message](#response-message-2)
-- [(rpc) ListLeft (`ruek.api.v1.Relations.ListLeft`)](#rpc-listleft-ruekapiv1relationslistleft)
+- [(rpc) Delete by Id (`ruek.api.v1.Relations.DeleteById`)](#rpc-delete-by-id-ruekapiv1relationsdeletebyid)
   - [Request message](#request-message-3)
   - [Response message](#response-message-3)
-- [(rpc) ListRight (`ruek.api.v1.Relations.ListRight`)](#rpc-listright-ruekapiv1relationslistright)
+- [(rpc) ListLeft (`ruek.api.v1.Relations.ListLeft`)](#rpc-listleft-ruekapiv1relationslistleft)
   - [Request message](#request-message-4)
   - [Response message](#response-message-4)
+- [(rpc) ListRight (`ruek.api.v1.Relations.ListRight`)](#rpc-listright-ruekapiv1relationslistright)
+  - [Request message](#request-message-5)
+  - [Response message](#response-message-5)
 - [Messages](#messages)
   - [Entity](#entity)
   - [Tuple](#tuple)
@@ -31,6 +34,8 @@ service Relations {}
   - [RelationsCreateResponse](#relationscreateresponse)
   - [RelationsDeleteRequest](#relationsdeleterequest)
   - [RelationsDeleteResponse](#relationsdeleteresponse)
+  - [RelationsDeleteByIdRequest](#relationsdeletebyidrequest)
+  - [RelationsDeleteByIdResponse](#relationsdeletebyidresponse)
   - [RelationsListLeftRequest](#relationslistleftrequest)
   - [RelationsListLeftResponse](#relationslistleftresponse)
   - [RelationsListRightRequest](#relationslistrightrequest)
@@ -89,6 +94,23 @@ rpc Delete(RelationsDeleteRequest) returns (RelationsDeleteResponse);
 ### Response message
 
 [`RelationsDeleteResponse`](#relationsdeleteresponse)
+
+
+## (rpc) Delete by Id (`ruek.api.v1.Relations.DeleteById`)
+
+Delete an existing relation using the relation tuple id.
+
+```proto
+rpc Delete(RelationsDeleteByIdRequest) returns (RelationsDeleteByIdResponse);
+```
+
+### Request message
+
+[`RelationsDeleteByIdRequest`](#relationsdeletebyidrequest)
+
+### Response message
+
+[`RelationsDeleteByIdResponse`](#relationsdeletebyidresponse)
 
 
 ## (rpc) ListLeft (`ruek.api.v1.Relations.ListLeft`)
@@ -216,6 +238,17 @@ rpc ListRight(RelationsListRightRequest) returns (RelationsListRightResponse);
 
 | Field  | Type | Description |
 | ------ | ---- | ----------- |
+
+### RelationsDeleteByIdRequest
+
+| Field  | Type     | Description |
+| ------ | -------- | ----------- |
+| id     | `string` | Relation tuple id to delete. |
+
+### RelationsDeleteByIdResponse
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
 
 ### RelationsListLeftRequest
 

--- a/proto/ruek/api/v1/principals.proto
+++ b/proto/ruek/api/v1/principals.proto
@@ -32,9 +32,20 @@ message PrincipalsCreateResponse {
 
 message PrincipalsDeleteRequest {
 	string id = 1;
+
+	// Limits the delete cost. The value must be within `1` and `65535`. Defaults to `1000`.
+	optional uint32 cost_limit = 7;
 }
 
-message PrincipalsDeleteResponse {}
+message PrincipalsDeleteResponse {
+	// Cost of delete. A negative cost indicates the delete cost exceeded the limit and the delete
+	// action was aborted.
+	int32 cost = 1;
+
+	// List of relation tuple ids that were referencing the deleted principal but failed to delete.
+	// The caller must delete these tuples to ensure data consistency.
+	repeated string failed_tuple_ids = 2;
+}
 
 message PrincipalsListRequest {
 	optional string segment = 1;

--- a/proto/ruek/api/v1/relations.proto
+++ b/proto/ruek/api/v1/relations.proto
@@ -8,6 +8,7 @@ service Relations {
 	rpc Check(RelationsCheckRequest) returns (RelationsCheckResponse);
 	rpc Create(RelationsCreateRequest) returns (RelationsCreateResponse);
 	rpc Delete(RelationsDeleteRequest) returns (RelationsDeleteResponse);
+	rpc DeleteById(RelationsDeleteByIdRequest) returns (RelationsDeleteByIdResponse);
 	rpc ListLeft(RelationsListLeftRequest) returns (RelationsListLeftResponse);
 	rpc ListRight(RelationsListRightRequest) returns (RelationsListRightResponse);
 }
@@ -148,6 +149,12 @@ message RelationsDeleteRequest {
 }
 
 message RelationsDeleteResponse {}
+
+message RelationsDeleteByIdRequest {
+	string id = 1;
+}
+
+message RelationsDeleteByIdResponse {}
 
 message RelationsListLeftRequest {
 	oneof right {

--- a/src/db/principals_test.cpp
+++ b/src/db/principals_test.cpp
@@ -11,12 +11,12 @@ protected:
 		db::testing::setup();
 
 		// Clear data
-		db::pg::exec("truncate table principals cascade;");
+		db::pg::exec("truncate table principals;");
 	}
 
 	void SetUp() {
 		// Clear data before each test
-		db::pg::exec("delete from principals cascade;");
+		db::pg::exec("delete from principals;");
 	}
 
 	static void TearDownTestSuite() { db::testing::teardown(); }

--- a/src/db/principals_test.cpp
+++ b/src/db/principals_test.cpp
@@ -29,7 +29,7 @@ TEST_F(db_PrincipalsTest, discard) {
 	ASSERT_NO_THROW(principal.store());
 
 	bool result = false;
-	ASSERT_NO_THROW(result = db::Principal::discard("", principal.id()));
+	ASSERT_NO_THROW(result = db::Principal::discard({}, principal.id()));
 	EXPECT_TRUE(result);
 
 	std::string_view qry = R"(

--- a/src/db/tuples.cpp
+++ b/src/db/tuples.cpp
@@ -5,32 +5,29 @@
 
 #include "err/errors.h"
 
-#include "common.h"
 #include "detail.h"
 
 namespace db {
 Tuple::Tuple(const Tuple::Data &data) noexcept :
 	_data(data), _id(), _rev(detail::rand()), _lHash(), _rHash(), _ridL(), _ridR() {
-	sanitise();
+	hash();
 }
 
 Tuple::Tuple(Tuple::Data &&data) noexcept :
 	_data(std::move(data)), _id(), _rev(detail::rand()), _lHash(), _rHash(), _ridL(), _ridR() {
-	sanitise();
+	hash();
 }
 
 Tuple::Tuple(const pg::row_t &r) :
 	_data({
-		.attrs        = r["attrs"].as<Data::attrs_t>(),
-		.lEntityId    = r["l_entity_id"].as<std::string>(),
-		.lEntityType  = r["l_entity_type"].as<std::string>(),
-		.lPrincipalId = r["l_principal_id"].as<Data::pid_t>(),
-		.relation     = r["relation"].as<std::string>(),
-		.rEntityId    = r["r_entity_id"].as<std::string>(),
-		.rEntityType  = r["r_entity_type"].as<std::string>(),
-		.rPrincipalId = r["r_principal_id"].as<Data::pid_t>(),
-		.spaceId      = r["space_id"].as<std::string>(),
-		.strand       = r["strand"].as<std::string>(),
+		.attrs       = r["attrs"].as<Data::attrs_t>(),
+		.lEntityId   = r["l_entity_id"].as<std::string>(),
+		.lEntityType = r["l_entity_type"].as<std::string>(),
+		.relation    = r["relation"].as<std::string>(),
+		.rEntityId   = r["r_entity_id"].as<std::string>(),
+		.rEntityType = r["r_entity_type"].as<std::string>(),
+		.spaceId     = r["space_id"].as<std::string>(),
+		.strand      = r["strand"].as<std::string>(),
 	}),
 	_id(r["_id"].as<std::string>()), _rev(r["_rev"].as<int>()),
 	_lHash(r["_l_hash"].as<std::int64_t>()), _rHash(r["_r_hash"].as<std::int64_t>()),
@@ -38,14 +35,12 @@ Tuple::Tuple(const pg::row_t &r) :
 
 Tuple::Tuple(const Tuple &left, const Tuple &right) noexcept :
 	_data({
-		.lEntityId    = left.lEntityId(),
-		.lEntityType  = left.lEntityType(),
-		.lPrincipalId = left.lPrincipalId(),
-		.relation     = right.relation(),
-		.rEntityId    = right.rEntityId(),
-		.rEntityType  = right.rEntityType(),
-		.rPrincipalId = right.rPrincipalId(),
-		.spaceId      = left.spaceId(),
+		.lEntityId   = left.lEntityId(),
+		.lEntityType = left.lEntityType(),
+		.relation    = right.relation(),
+		.rEntityId   = right.rEntityId(),
+		.rEntityType = right.rEntityType(),
+		.spaceId     = left.spaceId(),
 	}),
 	_id(), _rev(0), _lHash(left.lHash()), _rHash(right.rHash()), _ridL(left.id()),
 	_ridR(right.id()) {}
@@ -87,7 +82,6 @@ Tuple Tuple::retrieve(std::string_view id) {
 			relation,
 			r_entity_type, r_entity_id,
 			attrs,
-			l_principal_id, r_principal_id,
 			_id, _rev,
 			_l_hash, _r_hash,
 			_rid_l, _rid_r
@@ -103,20 +97,6 @@ Tuple Tuple::retrieve(std::string_view id) {
 	return Tuple(res[0]);
 }
 
-void Tuple::sanitise() noexcept {
-	if (_data.lPrincipalId) {
-		_data.lEntityId   = *_data.lPrincipalId;
-		_data.lEntityType = common::principal_entity_v;
-	}
-
-	if (_data.rPrincipalId) {
-		_data.rEntityId   = *_data.rPrincipalId;
-		_data.rEntityType = common::principal_entity_v;
-	}
-
-	hash();
-}
-
 void Tuple::store() {
 	if (_id.empty()) {
 		_id = xid::next();
@@ -130,7 +110,6 @@ void Tuple::store() {
 			relation,
 			r_entity_type, r_entity_id,
 			attrs,
-			l_principal_id, r_principal_id,
 			_id, _rev,
 			_l_hash, _r_hash,
 			_rid_l, _rid_r
@@ -141,10 +120,9 @@ void Tuple::store() {
 			$5::text,
 			$6::text, $7::text,
 			$8::jsonb,
-			$9::text, $10::text,
-			$11::text, $12::integer,
-			$13::bigint, $14::bigint,
-			$15::text, $16::text
+			$9::text, $10::integer,
+			$11::bigint, $12::bigint,
+			$13::text, $14::text
 		)
 		on conflict (_id)
 		do update
@@ -155,7 +133,7 @@ void Tuple::store() {
 				$8::jsonb,
 				excluded._rev + 1
 			)
-			where t._rev = $12::integer
+			where t._rev = $10::integer
 		returning _rev;
 	)";
 
@@ -171,8 +149,6 @@ void Tuple::store() {
 			_data.rEntityType,
 			_data.rEntityId,
 			_data.attrs,
-			_data.lPrincipalId,
-			_data.rPrincipalId,
 			_id,
 			_rev,
 			_lHash,
@@ -181,8 +157,6 @@ void Tuple::store() {
 			_ridR);
 	} catch (pqxx::check_violation &) {
 		throw err::DbTupleInvalidData();
-	} catch (pg::fkey_violation_t &) {
-		throw err::DbTupleInvalidKey();
 	} catch (pqxx::unique_violation &e) {
 		throw err::DbTupleAlreadyExists();
 	}
@@ -266,7 +240,6 @@ Tuples ListTuples(
 				relation,
 				r_entity_type, r_entity_id,
 				attrs,
-				l_principal_id, r_principal_id,
 				_id, _rev,
 				_l_hash, _r_hash,
 				_rid_l, _rid_r
@@ -341,7 +314,6 @@ Tuples LookupTuples(
 				relation,
 				r_entity_type, r_entity_id,
 				attrs,
-				l_principal_id, r_principal_id,
 				_id, _rev,
 				_l_hash, _r_hash,
 				_rid_l, _rid_r

--- a/src/db/tuples.cpp
+++ b/src/db/tuples.cpp
@@ -45,14 +45,15 @@ Tuple::Tuple(const Tuple &left, const Tuple &right) noexcept :
 	_id(), _rev(0), _lHash(left.lHash()), _rHash(right.rHash()), _ridL(left.id()),
 	_ridR(right.id()) {}
 
-bool Tuple::discard(std::string_view id) {
+bool Tuple::discard(std::string_view spaceId, std::string_view id) {
 	std::string_view qry = R"(
 		delete from tuples
 		where
-			_id = $1::text;
+			space_id = $1::text
+			and _id = $2::text;
 	)";
 
-	auto res = pg::exec(qry, id);
+	auto res = pg::exec(qry, spaceId, id);
 	return (res.affected_rows() == 1);
 }
 

--- a/src/db/tuples.h
+++ b/src/db/tuples.h
@@ -4,28 +4,27 @@
 #include <string>
 #include <vector>
 
+#include "common.h"
 #include "pg.h"
 
 namespace db {
 class Tuple {
 public:
+	using pid_t = std::optional<std::string>;
 	using rid_t = std::optional<std::string>;
 
 	struct Data {
 		using attrs_t = std::optional<std::string>;
-		using pid_t   = std::optional<std::string>;
 
 		attrs_t attrs;
 
 		std::string lEntityId;
 		std::string lEntityType;
-		pid_t       lPrincipalId;
 
 		std::string relation;
 
 		std::string rEntityId;
 		std::string rEntityType;
-		pid_t       rPrincipalId;
 
 		std::string spaceId;
 		std::string strand;
@@ -63,22 +62,40 @@ public:
 
 	const std::string &lEntityId() const noexcept { return _data.lEntityId; }
 	const std::string &lEntityType() const noexcept { return _data.lEntityType; }
-	const Data::pid_t &lPrincipalId() const noexcept { return _data.lPrincipalId; }
+
+	const pid_t lPrincipalId() const noexcept {
+		if (_data.lEntityType == common::principal_entity_v) {
+			return _data.lEntityId;
+		}
+
+		return {};
+	}
 
 	void lPrincipalId(const std::string &pid) noexcept {
-		_data.lPrincipalId = pid;
-		sanitise();
+		_data.lEntityId   = pid;
+		_data.lEntityType = common::principal_entity_v;
+
+		hash();
 	}
 
 	const std::string &relation() const noexcept { return _data.relation; }
 
 	const std::string &rEntityId() const noexcept { return _data.rEntityId; }
 	const std::string &rEntityType() const noexcept { return _data.rEntityType; }
-	const Data::pid_t &rPrincipalId() const noexcept { return _data.rPrincipalId; }
+
+	const pid_t rPrincipalId() const noexcept {
+		if (_data.rEntityType == common::principal_entity_v) {
+			return _data.rEntityId;
+		}
+
+		return {};
+	}
 
 	void rPrincipalId(const std::string &pid) noexcept {
-		_data.rPrincipalId = pid;
-		sanitise();
+		_data.rEntityId   = pid;
+		_data.rEntityType = common::principal_entity_v;
+
+		hash();
 	}
 
 	const std::string &spaceId() const noexcept { return _data.spaceId; }
@@ -107,8 +124,6 @@ public:
 
 private:
 	void hash() noexcept;
-
-	void sanitise() noexcept;
 
 	Data         _data;
 	std::string  _id;

--- a/src/db/tuples.h
+++ b/src/db/tuples.h
@@ -114,7 +114,7 @@ public:
 
 	void store();
 
-	static bool discard(std::string_view id);
+	static bool discard(std::string_view spaceId, std::string_view id);
 
 	static std::optional<Tuple> lookup(
 		std::string_view spaceId, Entity left, Entity right, std::string_view relation = "",

--- a/src/db/tuples_test.cpp
+++ b/src/db/tuples_test.cpp
@@ -79,7 +79,7 @@ TEST_F(db_TuplesTest, discard) {
 	ASSERT_NO_THROW(tuple.store());
 
 	bool result = false;
-	ASSERT_NO_THROW(result = db::Tuple::discard(tuple.id()));
+	ASSERT_NO_THROW(result = db::Tuple::discard({}, tuple.id()));
 	EXPECT_TRUE(result);
 
 	std::string_view qry = R"(
@@ -97,7 +97,7 @@ TEST_F(db_TuplesTest, discard) {
 	EXPECT_EQ(0, count);
 
 	// Idempotency
-	ASSERT_NO_THROW(result = db::Tuple::discard(tuple.id()));
+	ASSERT_NO_THROW(result = db::Tuple::discard({}, tuple.id()));
 	EXPECT_FALSE(result);
 }
 

--- a/src/db/tuples_test.cpp
+++ b/src/db/tuples_test.cpp
@@ -101,6 +101,21 @@ TEST_F(db_TuplesTest, discard) {
 	EXPECT_FALSE(result);
 }
 
+TEST_F(db_TuplesTest, hash) {
+	// Success: hash data
+	{
+		db::Tuple tuple({
+			.lEntityId   = "lid:dummy",
+			.lEntityType = "ltype:dummy",
+			.rEntityId   = "rid:dummy",
+			.rEntityType = "rtype:dummy",
+		});
+
+		EXPECT_EQ(db::Tuple::Entity(tuple.lEntityType(), tuple.lEntityId()).hash(), tuple.lHash());
+		EXPECT_EQ(db::Tuple::Entity(tuple.rEntityType(), tuple.rEntityId()).hash(), tuple.rHash());
+	}
+}
+
 TEST_F(db_TuplesTest, list) {
 	// Seed tuple to check other tests are only returning expected results
 	db::Tuple tuple({
@@ -548,28 +563,6 @@ TEST_F(db_TuplesTest, rev) {
 	}
 }
 
-TEST_F(db_TuplesTest, sanitise) {
-	// Success: sanitise data
-	{
-		db::Tuple tuple({
-			.lEntityId    = "lid:dummy",
-			.lEntityType  = "ltype:dummy",
-			.lPrincipalId = "left:db_TuplesTest.sanitise",
-			.rEntityId    = "rid:dummy",
-			.rEntityType  = "rtype:dummy",
-			.rPrincipalId = "right:db_TuplesTest.sanitise",
-		});
-
-		EXPECT_EQ(db::common::principal_entity_v, tuple.lEntityType());
-		EXPECT_EQ(tuple.lPrincipalId(), tuple.lEntityId());
-		EXPECT_EQ(db::common::principal_entity_v, tuple.rEntityType());
-		EXPECT_EQ(tuple.rPrincipalId(), tuple.rEntityId());
-
-		EXPECT_EQ(db::Tuple::Entity(tuple.lEntityType(), tuple.lEntityId()).hash(), tuple.lHash());
-		EXPECT_EQ(db::Tuple::Entity(tuple.rEntityType(), tuple.rEntityId()).hash(), tuple.rHash());
-	}
-}
-
 TEST_F(db_TuplesTest, store) {
 	// Success: persist data
 	{
@@ -590,7 +583,6 @@ TEST_F(db_TuplesTest, store) {
 				relation,
 				r_entity_type, r_entity_id,
 				attrs,
-				l_principal_id, r_principal_id,
 				_id, _rev,
 				_l_hash, _r_hash,
 				_rid_l, _rid_r
@@ -610,8 +602,6 @@ TEST_F(db_TuplesTest, store) {
 			 rEntityType,
 			 rEntityId,
 			 attrs,
-			 lPrincipalId,
-			 rPrincipalId,
 			 _id,
 			 _rev,
 			 _lHash,
@@ -627,8 +617,6 @@ TEST_F(db_TuplesTest, store) {
 						std::string,
 						std::string,
 						db::Tuple::Data::attrs_t,
-						db::Tuple::Data::pid_t,
-						db::Tuple::Data::pid_t,
 						std::string,
 						int,
 						std::int64_t,
@@ -644,8 +632,6 @@ TEST_F(db_TuplesTest, store) {
 		EXPECT_EQ(tuple.rEntityType(), rEntityType);
 		EXPECT_EQ(tuple.rEntityId(), rEntityId);
 		EXPECT_EQ(tuple.attrs(), attrs);
-		EXPECT_EQ(tuple.lPrincipalId(), lPrincipalId);
-		EXPECT_EQ(tuple.rPrincipalId(), rPrincipalId);
 		EXPECT_EQ(tuple.id(), _id);
 		EXPECT_EQ(tuple.rev(), _rev);
 		EXPECT_EQ(tuple.lHash(), _lHash);
@@ -666,17 +652,5 @@ TEST_F(db_TuplesTest, store) {
 		});
 
 		EXPECT_THROW(tuple.store(), err::DbTupleInvalidData);
-	}
-
-	// Error: invalid `l_principal_id`
-	{
-		db::Tuple tuple({
-			.lPrincipalId = "dummy",
-			.relation     = "relation",
-			.rEntityId    = "right",
-			.rEntityType  = "db_TuplesTest.store-invalid_l_principal_id",
-		});
-
-		EXPECT_THROW(tuple.store(), err::DbTupleInvalidKey);
 	}
 }

--- a/src/db/tuples_test.cpp
+++ b/src/db/tuples_test.cpp
@@ -12,7 +12,7 @@ protected:
 		db::testing::setup();
 
 		// Clear data
-		db::pg::exec("truncate table principals cascade;");
+		db::pg::exec("truncate table principals;");
 		db::pg::exec("truncate table tuples;");
 	}
 

--- a/src/err/errors.h
+++ b/src/err/errors.h
@@ -14,8 +14,8 @@ using DbPrincipalNotFound    = basic_error<"ruek:1.2.2.404", "Principal not foun
 using DbRecordInvalidData        = basic_error<"ruek:1.3.1.400", "Invalid principal data">;
 using DbRecordInvalidPrincipalId = basic_error<"ruek:1.3.2.400", "Invalid principal for record">;
 
-using DbTupleAlreadyExists = basic_error<"ruek:1.4.4.409", "Tuple already exists">;
-using DbTupleInvalidData   = basic_error<"ruek:1.4.1.400", "Invalid tuple data">;
+using DbTupleAlreadyExists = basic_error<"ruek:1.4.1.409", "Tuple already exists">;
+using DbTupleInvalidData   = basic_error<"ruek:1.4.2.400", "Invalid tuple data">;
 using DbTupleNotFound      = basic_error<"ruek:1.4.3.404", "Tuple not found">;
 
 using DbTuplesInvalidListArgs =

--- a/src/err/errors.h
+++ b/src/err/errors.h
@@ -16,7 +16,6 @@ using DbRecordInvalidPrincipalId = basic_error<"ruek:1.3.2.400", "Invalid princi
 
 using DbTupleAlreadyExists = basic_error<"ruek:1.4.4.409", "Tuple already exists">;
 using DbTupleInvalidData   = basic_error<"ruek:1.4.1.400", "Invalid tuple data">;
-using DbTupleInvalidKey    = basic_error<"ruek:1.4.2.400", "Invalid reference key for tuple">;
 using DbTupleNotFound      = basic_error<"ruek:1.4.3.404", "Tuple not found">;
 
 using DbTuplesInvalidListArgs =

--- a/src/err/errors.h
+++ b/src/err/errors.h
@@ -28,4 +28,5 @@ using RpcPrincipalsAlreadyExists = basic_error<"ruek:2.1.1.409", "Principal alre
 using RpcPrincipalsNotFound      = basic_error<"ruek:2.1.2.404", "Principal not found">;
 
 using RpcRelationsInvalidStrategy = basic_error<"ruek:2.2.1.400", "Invalid relations strategy">;
+using RpcRelationsNotFound        = basic_error<"ruek:2.2.2.404", "Relation not found">;
 } // namespace err

--- a/src/svc/principals.cpp
+++ b/src/svc/principals.cpp
@@ -64,9 +64,10 @@ rpcDelete::result_type Impl::call<rpcDelete>(
 		}
 
 		auto r = response.mutable_failed_tuple_ids();
+		auto spaceId = ctx.meta(common::space_id_v);
 		for (const auto &t : tuples) {
 			try {
-				db::Tuple::discard(t.id());
+				db::Tuple::discard(spaceId, t.id());
 			} catch (...) {
 				*r->Add() = t.id();
 			}

--- a/src/svc/principals.cpp
+++ b/src/svc/principals.cpp
@@ -59,12 +59,13 @@ rpcDelete::result_type Impl::call<rpcDelete>(
 
 	rpcDelete::response_type response;
 	if (cost < limit) {
-		if (auto r = db::Principal::discard(ctx.meta(common::space_id_v), req.id()); r == false) {
+		auto spaceId = ctx.meta(common::space_id_v);
+
+		if (auto r = db::Principal::discard(spaceId, req.id()); r == false) {
 			throw err::RpcPrincipalsNotFound();
 		}
 
 		auto r = response.mutable_failed_tuple_ids();
-		auto spaceId = ctx.meta(common::space_id_v);
 		for (const auto &t : tuples) {
 			try {
 				db::Tuple::discard(spaceId, t.id());

--- a/src/svc/relations.cpp
+++ b/src/svc/relations.cpp
@@ -247,7 +247,7 @@ rpcDelete::result_type Impl::call<rpcDelete>(
 	if (auto r = db::Tuple::lookup(
 			ctx.meta(common::space_id_v), left, right, req.relation(), req.strand());
 		r) {
-		db::Tuple::discard(r->id());
+		db::Tuple::discard(ctx.meta(common::space_id_v), r->id());
 	}
 
 	return {grpcxx::status::code_t::ok, rpcDelete::response_type()};

--- a/src/svc/relations.cpp
+++ b/src/svc/relations.cpp
@@ -248,6 +248,8 @@ rpcDelete::result_type Impl::call<rpcDelete>(
 			ctx.meta(common::space_id_v), left, right, req.relation(), req.strand());
 		r) {
 		db::Tuple::discard(ctx.meta(common::space_id_v), r->id());
+	} else {
+		throw err::RpcRelationsNotFound();
 	}
 
 	return {grpcxx::status::code_t::ok, rpcDelete::response_type()};

--- a/src/svc/relations.cpp
+++ b/src/svc/relations.cpp
@@ -254,6 +254,16 @@ rpcDelete::result_type Impl::call<rpcDelete>(
 }
 
 template <>
+rpcDeleteById::result_type Impl::call<rpcDeleteById>(
+	grpcxx::context &ctx, const rpcDeleteById::request_type &req) {
+	if (auto r = db::Tuple::discard(ctx.meta(common::space_id_v), req.id()); r == false) {
+		throw err::RpcRelationsNotFound();
+	}
+
+	return {grpcxx::status::code_t::ok, rpcDeleteById::response_type()};
+}
+
+template <>
 rpcListLeft::result_type Impl::call<rpcListLeft>(
 	grpcxx::context &ctx, const rpcListLeft::request_type &req) {
 
@@ -360,6 +370,9 @@ google::rpc::Status Impl::exception() noexcept {
 		status.set_message(std::string(e.str()));
 	} catch (const err::RpcRelationsInvalidStrategy &e) {
 		status.set_code(google::rpc::INVALID_ARGUMENT);
+		status.set_message(std::string(e.str()));
+	} catch (const err::RpcRelationsNotFound &e) {
+		status.set_code(google::rpc::NOT_FOUND);
 		status.set_message(std::string(e.str()));
 	} catch (const std::exception &e) {
 		status.set_code(google::rpc::INTERNAL);

--- a/src/svc/relations.h
+++ b/src/svc/relations.h
@@ -65,6 +65,10 @@ rpcDelete::result_type Impl::call<rpcDelete>(
 	grpcxx::context &ctx, const rpcDelete::request_type &req);
 
 template <>
+rpcDeleteById::result_type Impl::call<rpcDeleteById>(
+	grpcxx::context &ctx, const rpcDeleteById::request_type &req);
+
+template <>
 rpcListLeft::result_type Impl::call<rpcListLeft>(
 	grpcxx::context &ctx, const rpcListLeft::request_type &req);
 

--- a/src/svc/relations_test.cpp
+++ b/src/svc/relations_test.cpp
@@ -1027,7 +1027,9 @@ TEST_F(svc_RelationsTest, Create) {
 		EXPECT_NO_THROW(result = svc.call<rpcCreate>(ctx, request));
 
 		EXPECT_EQ(grpcxx::status::code_t::invalid_argument, result.status.code());
-		ASSERT_FALSE(result.response);
+		EXPECT_EQ("CAMSI1tydWVrOjEuNC4yLjQwMF0gSW52YWxpZCB0dXBsZSBkYXRh", result.status.details());
+
+		EXPECT_FALSE(result.response);
 	}
 
 	// Error: invalid principal
@@ -1047,7 +1049,10 @@ TEST_F(svc_RelationsTest, Create) {
 		EXPECT_NO_THROW(result = svc.call<rpcCreate>(ctx, request));
 
 		EXPECT_EQ(grpcxx::status::code_t::invalid_argument, result.status.code());
-		ASSERT_FALSE(result.response);
+		EXPECT_EQ(
+			"CAMSJFtydWVrOjEuMi4yLjQwNF0gUHJpbmNpcGFsIG5vdCBmb3VuZA==", result.status.details());
+
+		EXPECT_FALSE(result.response);
 	}
 
 	// Error: invalid optmization strategy
@@ -1094,7 +1099,7 @@ TEST_F(svc_RelationsTest, Create) {
 
 		EXPECT_EQ(grpcxx::status::code_t::already_exists, result.status.code());
 		EXPECT_EQ(
-			"CAYSJVtydWVrOjEuNC40LjQwOV0gVHVwbGUgYWxyZWFkeSBleGlzdHM=", result.status.details());
+			"CAYSJVtydWVrOjEuNC4xLjQwOV0gVHVwbGUgYWxyZWFkeSBleGlzdHM=", result.status.details());
 
 		EXPECT_FALSE(result.response);
 	}

--- a/src/svc/relations_test.cpp
+++ b/src/svc/relations_test.cpp
@@ -85,10 +85,10 @@ TEST_F(svc_RelationsTest, Check) {
 		ASSERT_NO_THROW(right.store());
 
 		db::Tuple tuple({
-			.lPrincipalId = left.id(),
-			.relation     = "relation",
-			.rPrincipalId = right.id(),
+			.relation = "relation",
 		});
+		tuple.lPrincipalId(left.id());
+		tuple.rPrincipalId(right.id());
 		ASSERT_NO_THROW(tuple.store());
 
 		rpcCheck::request_type request;
@@ -899,10 +899,10 @@ TEST_F(svc_RelationsTest, Create) {
 		}
 
 		db::Tuple tuple({
-			.lPrincipalId = principals[0].id(),
-			.relation     = "member",
-			.rPrincipalId = principals[1].id(),
+			.relation = "member",
 		});
+		tuple.lPrincipalId(principals[0].id());
+		tuple.rPrincipalId(principals[1].id());
 		ASSERT_NO_THROW(tuple.store());
 
 		rpcCreate::request_type request;
@@ -1152,12 +1152,12 @@ TEST_F(svc_RelationsTest, Delete) {
 		ASSERT_NO_THROW(right.store());
 
 		db::Tuple tuple({
-			.lPrincipalId = left.id(),
-			.relation     = "relation",
-			.rPrincipalId = right.id(),
-			.spaceId      = std::string(spaceId),
-			.strand       = "strand",
+			.relation = "relation",
+			.spaceId  = std::string(spaceId),
+			.strand   = "strand",
 		});
+		tuple.lPrincipalId(left.id());
+		tuple.rPrincipalId(right.id());
 		ASSERT_NO_THROW(tuple.store());
 
 		rpcDelete::request_type request;
@@ -1222,11 +1222,11 @@ TEST_F(svc_RelationsTest, ListLeft) {
 		ASSERT_NO_THROW(principal.store());
 
 		db::Tuple tuple({
-			.lEntityId    = "left",
-			.lEntityType  = "svc_RelationsTest.list",
-			.relation     = "relation",
-			.rPrincipalId = principal.id(),
+			.lEntityId   = "left",
+			.lEntityType = "svc_RelationsTest.list",
+			.relation    = "relation",
 		});
+		tuple.rPrincipalId(principal.id());
 		ASSERT_NO_THROW(tuple.store());
 
 		rpcListLeft::request_type request;
@@ -1448,11 +1448,11 @@ TEST_F(svc_RelationsTest, ListRight) {
 		ASSERT_NO_THROW(principal.store());
 
 		db::Tuple tuple({
-			.lPrincipalId = principal.id(),
-			.relation     = "relation",
-			.rEntityId    = "right",
-			.rEntityType  = "svc_RelationsTest.list",
+			.relation    = "relation",
+			.rEntityId   = "right",
+			.rEntityType = "svc_RelationsTest.list",
 		});
+		tuple.lPrincipalId(principal.id());
 		ASSERT_NO_THROW(tuple.store());
 
 		rpcListRight::request_type request;

--- a/src/svc/relations_test.cpp
+++ b/src/svc/relations_test.cpp
@@ -1184,7 +1184,7 @@ TEST_F(svc_RelationsTest, Delete) {
 		EXPECT_FALSE(db::Tuple::discard(spaceId, tuple.id()));
 	}
 
-	// Success: not found (strand mismatch)
+	// Error: not found (strand mismatch)
 	{
 		db::Tuple tuple({
 			.lEntityId   = "left",
@@ -1210,8 +1210,9 @@ TEST_F(svc_RelationsTest, Delete) {
 
 		rpcDelete::result_type result;
 		EXPECT_NO_THROW(result = svc.call<rpcDelete>(ctx, request));
-		EXPECT_EQ(grpcxx::status::code_t::ok, result.status.code());
-		EXPECT_TRUE(result.response);
+		EXPECT_EQ(grpcxx::status::code_t::not_found, result.status.code());
+		EXPECT_EQ("CAUSI1tydWVrOjIuMi4yLjQwNF0gUmVsYXRpb24gbm90IGZvdW5k", result.status.details());
+		EXPECT_FALSE(result.response);
 
 		EXPECT_TRUE(db::Tuple::discard({}, tuple.id()));
 	}

--- a/src/svc/relations_test.cpp
+++ b/src/svc/relations_test.cpp
@@ -15,7 +15,7 @@ protected:
 		db::testing::setup();
 
 		// Clear data
-		db::pg::exec("truncate table principals cascade;");
+		db::pg::exec("truncate table principals;");
 		db::pg::exec("truncate table tuples;");
 	}
 
@@ -1145,7 +1145,7 @@ TEST_F(svc_RelationsTest, Delete) {
 		std::string_view spaceId = "space_id:svc_RelationsTest.Delete-with_principals";
 
 		db::Principal left({
-			.id      = "id:ssvc_RelationsTest.Delete-with_principals_left",
+			.id      = "id:svc_RelationsTest.Delete-with_principals_left",
 			.spaceId = std::string(spaceId),
 		});
 		ASSERT_NO_THROW(left.store());

--- a/src/svc/relations_test.cpp
+++ b/src/svc/relations_test.cpp
@@ -1137,7 +1137,7 @@ TEST_F(svc_RelationsTest, Delete) {
 		EXPECT_EQ(grpcxx::status::code_t::ok, result.status.code());
 		EXPECT_TRUE(result.response);
 
-		EXPECT_FALSE(db::Tuple::discard(tuple.id()));
+		EXPECT_FALSE(db::Tuple::discard({}, tuple.id()));
 	}
 
 	// Success: delete with principals
@@ -1181,7 +1181,7 @@ TEST_F(svc_RelationsTest, Delete) {
 		EXPECT_EQ(grpcxx::status::code_t::ok, result.status.code());
 		EXPECT_TRUE(result.response);
 
-		EXPECT_FALSE(db::Tuple::discard(tuple.id()));
+		EXPECT_FALSE(db::Tuple::discard(spaceId, tuple.id()));
 	}
 
 	// Success: not found (strand mismatch)
@@ -1213,7 +1213,7 @@ TEST_F(svc_RelationsTest, Delete) {
 		EXPECT_EQ(grpcxx::status::code_t::ok, result.status.code());
 		EXPECT_TRUE(result.response);
 
-		EXPECT_TRUE(db::Tuple::discard(tuple.id()));
+		EXPECT_TRUE(db::Tuple::discard({}, tuple.id()));
 	}
 }
 


### PR DESCRIPTION
This change drops the foreign-key constraints from `tuples` which references `principals`. The constraint checks are now moved to the app layer with control over the cost for principal delete operations.

## Why?

Having fkey constraints will require additional indexes to ensure deletes aren't slow, which feels a bit unnecessary. Moving the checks to app layer will give more control over costs and more flexibility if needed (e.g. we can check if relations are valid when the principals are not "active").